### PR TITLE
feat: support SHA refs for plugin specs

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -61,11 +61,13 @@ Press ++prefix+shift+i++ to fetch and install all declared plugins.
 | Format | Example | Description |
 |---|---|---|
 | `user/repo` | `tmux-plugins/tmux-sensible` | GitHub shorthand |
-| `user/repo#branch` | `tmux-plugins/tmux-sensible#main` | Specific branch or tag |
+| `user/repo#ref` | `tmux-plugins/tmux-sensible#main` | Branch, tag, or commit SHA |
 | `https://github.com/user/repo.git` | `https://github.com/user/tmux-sensible.git` | Full HTTPS URL |
 | `git@github.com:user/plugin` | `git@github.com:tmux-plugins/tmux-sensible` | Full git SSH URL (GitHub) |
 | `git@bitbucket.com:user/plugin` | `git@bitbucket.com:user/tmux-plugin` | Non-GitHub git hosts |
 | `user/plugin alias=name` | `tmux-plugins/tmux-sensible alias=sensible` | Custom directory name |
+
+Branches track upstream and fast-forward on update. Tags and commit SHAs are pinned (detached HEAD; no automatic updates).
 
 For a list of compatible plugins, see the [tmux-plugins list](https://github.com/tmux-plugins/list).
 

--- a/docs/usage/managing-plugins.md
+++ b/docs/usage/managing-plugins.md
@@ -23,6 +23,17 @@ See [Interactive TUI — Browse Screen](interactive-tui.md#browse-screen) for th
 !!! tip
     You can also install plugins directly from the [browse screen](interactive-tui.md#browse-screen) without manually editing your config.
 
+## Pinning a plugin
+
+Append `#<ref>` to pin a plugin to a tag or commit SHA. Pinned plugins are not fast-forwarded on update.
+
+```tmux
+set -g @plugin 'catppuccin/tmux#v2.1.3'
+set -g @plugin 'tmux-plugins/tmux-sensible#abc1234'
+```
+
+To move to a new version, edit the ref in your config and run an update.
+
 ## Updating plugins
 
 Press ++prefix+shift+u++ to update plugins. The TUI opens and you can select which plugins to update.

--- a/internal/git/cli/cloner.go
+++ b/internal/git/cli/cloner.go
@@ -13,44 +13,67 @@ import (
 // Cloner clones git repositories using the git CLI.
 type Cloner struct{}
 
-// NewCloner returns a new Cloner.
 func NewCloner() *Cloner {
 	return &Cloner{}
 }
 
 func (c *Cloner) Clone(ctx context.Context, opts git.CloneOptions) error {
-	isSHA := opts.Branch != "" && looksLikeCommitSHA(opts.Branch)
+	// First try the ref as a branch or tag: `git clone -b` resolves both, so a
+	// branch/tag whose name happens to look like a hex SHA (e.g. "deadbeef") is
+	// handled here and never misclassified. git also keeps the requested depth.
+	err := c.cloneBranch(ctx, opts)
+	if err == nil {
+		return c.initSubmodules(ctx, opts)
+	}
 
-	args := []string{"clone"}
-	if !isSHA {
-		args = append(args, "--single-branch")
-		if opts.Depth > 0 {
-			args = append(args, "--depth", strconv.Itoa(opts.Depth))
-		}
-		if opts.Branch != "" {
-			args = append(args, "-b", opts.Branch)
-		}
+	// A real commit SHA is rejected by `git clone -b`. Only for SHA-shaped refs
+	// do we fall back to a full clone + checkout (a SHA may live anywhere in
+	// history, so the shallow/single-branch optimization cannot apply).
+	if !looksLikeCommitSHA(opts.Branch) {
+		return err
+	}
+	if err := c.cloneSHA(ctx, opts); err != nil {
+		return err
+	}
+	return c.initSubmodules(ctx, opts)
+}
+
+func (c *Cloner) cloneBranch(ctx context.Context, opts git.CloneOptions) error {
+	args := []string{"clone", "--single-branch"}
+	if opts.Depth > 0 {
+		args = append(args, "--depth", strconv.Itoa(opts.Depth))
+	}
+	if opts.Branch != "" {
+		args = append(args, "-b", opts.Branch)
 	}
 	args = append(args, opts.URL, opts.Dir)
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(cmd.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if err := cmd.Run(); err != nil {
+	return cmd.Run()
+}
+
+func (c *Cloner) cloneSHA(ctx context.Context, opts git.CloneOptions) error {
+	cloneCmd := exec.CommandContext(ctx, "git", "clone", opts.URL, opts.Dir)
+	cloneCmd.Env = append(cloneCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if err := cloneCmd.Run(); err != nil {
 		return err
 	}
 
-	if isSHA {
-		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", opts.Branch)
-		checkoutCmd.Dir = opts.Dir
-		checkoutCmd.Env = append(checkoutCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
-		if out, err := checkoutCmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git checkout %s: %w: %s", opts.Branch, err, strings.TrimSpace(string(out)))
-		}
+	// --end-of-options keeps a ref starting with "-" from being parsed as a
+	// git option (the ref comes from untrusted config).
+	checkoutCmd := exec.CommandContext(ctx, "git", "checkout", "--end-of-options", opts.Branch)
+	checkoutCmd.Dir = opts.Dir
+	checkoutCmd.Env = append(checkoutCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if out, err := checkoutCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git checkout %s: %w: %s", opts.Branch, err, strings.TrimSpace(string(out)))
 	}
+	return nil
+}
 
-	// Submodules are best-effort: a plugin whose submodule references an
-	// unreachable commit (see issue #14) should still install. The failure
-	// is surfaced via OnWarning so callers can notify the user.
+// Initializes submodules best-effort: a plugin whose submodule
+// references an unreachable commit (see TPM issue #14) should still install.
+func (c *Cloner) initSubmodules(ctx context.Context, opts git.CloneOptions) error {
 	subCmd := exec.CommandContext(ctx, "git", "submodule", "update", "--init", "--recursive")
 	subCmd.Dir = opts.Dir
 	subCmd.Env = append(subCmd.Environ(), "GIT_TERMINAL_PROMPT=0")

--- a/internal/git/cli/cloner.go
+++ b/internal/git/cli/cloner.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -18,12 +19,17 @@ func NewCloner() *Cloner {
 }
 
 func (c *Cloner) Clone(ctx context.Context, opts git.CloneOptions) error {
-	args := []string{"clone", "--single-branch"}
-	if opts.Depth > 0 {
-		args = append(args, "--depth", strconv.Itoa(opts.Depth))
-	}
-	if opts.Branch != "" {
-		args = append(args, "-b", opts.Branch)
+	isSHA := opts.Branch != "" && looksLikeCommitSHA(opts.Branch)
+
+	args := []string{"clone"}
+	if !isSHA {
+		args = append(args, "--single-branch")
+		if opts.Depth > 0 {
+			args = append(args, "--depth", strconv.Itoa(opts.Depth))
+		}
+		if opts.Branch != "" {
+			args = append(args, "-b", opts.Branch)
+		}
 	}
 	args = append(args, opts.URL, opts.Dir)
 
@@ -31,6 +37,15 @@ func (c *Cloner) Clone(ctx context.Context, opts git.CloneOptions) error {
 	cmd.Env = append(cmd.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+
+	if isSHA {
+		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", opts.Branch)
+		checkoutCmd.Dir = opts.Dir
+		checkoutCmd.Env = append(checkoutCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+		if out, err := checkoutCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git checkout %s: %w: %s", opts.Branch, err, strings.TrimSpace(string(out)))
+		}
 	}
 
 	// Submodules are best-effort: a plugin whose submodule references an

--- a/internal/git/cli/cloner_test.go
+++ b/internal/git/cli/cloner_test.go
@@ -68,6 +68,79 @@ func TestCloner_CloneWithBranch(t *testing.T) {
 	}
 }
 
+func TestCloner_CloneWithTag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+
+	// Tag the bare repo's HEAD via a temporary working copy.
+	work := cloneLocal(t, bare)
+	runGit(t, work, "tag", "v1.0.0")
+	runGit(t, work, "push", "origin", "v1.0.0")
+
+	dst := filepath.Join(t.TempDir(), "cloned-tag")
+	cloner := gitcli.NewCloner()
+	err := cloner.Clone(context.Background(), git.CloneOptions{
+		URL:    bare,
+		Dir:    dst,
+		Branch: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("Clone with tag returned error: %v", err)
+	}
+
+	// README from the initial (tagged) commit must exist.
+	if _, err := os.Stat(filepath.Join(dst, "README")); err != nil {
+		t.Fatalf("expected README in cloned repo: %v", err)
+	}
+
+	// HEAD should be detached when cloning a tag.
+	symCmd := exec.CommandContext(context.Background(), "git", "-C", dst, "symbolic-ref", "-q", "HEAD")
+	if err := symCmd.Run(); err == nil {
+		t.Fatal("expected detached HEAD after cloning a tag")
+	}
+}
+
+func TestCloner_CloneWithCommitSHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+
+	// Capture the commit SHA of the bare repo's HEAD.
+	work := cloneLocal(t, bare)
+	revOut, err := exec.CommandContext(context.Background(),
+		"git", "-C", work, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD failed: %v", err)
+	}
+	sha := strings.TrimSpace(string(revOut))
+
+	dst := filepath.Join(t.TempDir(), "cloned-sha")
+	cloner := gitcli.NewCloner()
+	err = cloner.Clone(context.Background(), git.CloneOptions{
+		URL:    bare,
+		Dir:    dst,
+		Branch: sha,
+	})
+	if err != nil {
+		t.Fatalf("Clone with commit SHA returned error: %v", err)
+	}
+
+	// HEAD must match the requested SHA exactly.
+	headOut, err := exec.CommandContext(context.Background(),
+		"git", "-C", dst, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD on cloned repo failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(headOut)); got != sha {
+		t.Fatalf("HEAD = %s, want %s", got, sha)
+	}
+}
+
 func TestCloner_CloneInvalidURL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git CLI test in short mode")

--- a/internal/git/cli/cloner_test.go
+++ b/internal/git/cli/cloner_test.go
@@ -68,6 +68,52 @@ func TestCloner_CloneWithBranch(t *testing.T) {
 	}
 }
 
+// A tag whose name looks like a commit SHA (all hex, 7-40 chars) must still be
+// treated as a tag: cloned via `git clone -b` (honoring Depth), not via the
+// full-clone SHA fallback that ignores Depth.
+func TestCloner_CloneWithHexNamedTag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+
+	// Add a second commit so a shallow (depth 1) clone is observable, then tag
+	// the tip with a hex-looking name that matches looksLikeCommitSHA.
+	work := cloneLocal(t, bare)
+	writeFile(t, filepath.Join(work, "second.txt"), "second")
+	runGit(t, work, "add", ".")
+	runGit(t, work, "commit", "-m", "second commit")
+	runGit(t, work, "push", "origin", "HEAD")
+	runGit(t, work, "tag", "abc1234")
+	runGit(t, work, "push", "origin", "abc1234")
+
+	dst := filepath.Join(t.TempDir(), "cloned-hextag")
+	cloner := gitcli.NewCloner()
+	err := cloner.Clone(context.Background(), git.CloneOptions{
+		// file:// so git honors --depth (it is ignored for local-path clones).
+		URL:    "file://" + bare,
+		Dir:    dst,
+		Branch: "abc1234",
+		Depth:  1,
+	})
+	if err != nil {
+		t.Fatalf("Clone with hex-named tag returned error: %v", err)
+	}
+
+	// Treated as a tag → detached HEAD.
+	symCmd := exec.CommandContext(context.Background(), "git", "-C", dst, "symbolic-ref", "-q", "HEAD")
+	if err := symCmd.Run(); err == nil {
+		t.Fatal("expected detached HEAD after cloning a hex-named tag")
+	}
+
+	// Cloned via -b with --depth → shallow. The SHA fallback would do a full
+	// clone (no .git/shallow), so its presence proves the tag path was taken.
+	if _, err := os.Stat(filepath.Join(dst, ".git", "shallow")); err != nil {
+		t.Fatalf("expected shallow clone (.git/shallow) for hex-named tag with Depth=1: %v", err)
+	}
+}
+
 func TestCloner_CloneWithTag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git CLI test in short mode")

--- a/internal/git/cli/fetcher.go
+++ b/internal/git/cli/fetcher.go
@@ -16,7 +16,9 @@ func NewFetcher() *Fetcher {
 }
 
 func (c *Fetcher) IsOutdated(ctx context.Context, dir string) (bool, error) {
-	// Detached HEAD (exit 1) means the plugin is pinned to a tag/SHA; never outdated.
+	// symbolic-ref -q HEAD: exit 0 = on a branch, exit 1 = detached HEAD
+	// (pinned to a tag/SHA; never outdated). Any other failure (not a repo,
+	// git missing, ...) is a real error and must be surfaced, not swallowed.
 	symCmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
 	symCmd.Dir = dir
 	if err := symCmd.Run(); err != nil {
@@ -24,6 +26,7 @@ func (c *Fetcher) IsOutdated(ctx context.Context, dir string) (bool, error) {
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return false, nil
 		}
+		return false, fmt.Errorf("git symbolic-ref in %s: %w", dir, err)
 	}
 
 	fetchCmd := exec.CommandContext(ctx, "git", "fetch")

--- a/internal/git/cli/fetcher.go
+++ b/internal/git/cli/fetcher.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -15,6 +16,16 @@ func NewFetcher() *Fetcher {
 }
 
 func (c *Fetcher) IsOutdated(ctx context.Context, dir string) (bool, error) {
+	// Detached HEAD (exit 1) means the plugin is pinned to a tag/SHA; never outdated.
+	symCmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
+	symCmd.Dir = dir
+	if err := symCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+	}
+
 	fetchCmd := exec.CommandContext(ctx, "git", "fetch")
 	fetchCmd.Dir = dir
 	fetchCmd.Env = append(fetchCmd.Environ(), "GIT_TERMINAL_PROMPT=0")

--- a/internal/git/cli/fetcher_test.go
+++ b/internal/git/cli/fetcher_test.go
@@ -8,6 +8,29 @@ import (
 	gitcli "github.com/tmuxpack/tpack/internal/git/cli"
 )
 
+func TestFetcher_IsOutdatedDetachedHEAD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	clone := cloneLocal(t, bare)
+	sha := revParse(t, clone, "HEAD")
+	runGit(t, clone, "checkout", sha)
+
+	// Upstream moves forward; pinned plugin must still report not outdated.
+	addCommitToBare(t, bare, "after-pin.txt")
+
+	fetcher := gitcli.NewFetcher()
+	outdated, err := fetcher.IsOutdated(context.Background(), clone)
+	if err != nil {
+		t.Fatalf("IsOutdated returned error: %v", err)
+	}
+	if outdated {
+		t.Fatal("expected pinned (detached HEAD) repo to report not outdated")
+	}
+}
+
 func TestFetcher_IsOutdatedUpToDate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git CLI test in short mode")

--- a/internal/git/cli/fetcher_test.go
+++ b/internal/git/cli/fetcher_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,5 +85,27 @@ func TestFetcher_IsOutdatedNonGitDir(t *testing.T) {
 	_, err := fetcher.IsOutdated(ctx, dir)
 	if err == nil {
 		t.Fatal("expected error when checking non-git directory")
+	}
+}
+
+// A symbolic-ref failure that is not exit 1 (detached HEAD) must be surfaced
+// rather than swallowed. A non-git directory makes symbolic-ref exit 128.
+func TestFetcher_IsOutdatedReportsSymbolicRefFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	fetcher := gitcli.NewFetcher()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := fetcher.IsOutdated(ctx, dir)
+	if err == nil {
+		t.Fatal("expected error for non-git directory")
+	}
+	if !strings.Contains(err.Error(), "symbolic-ref") {
+		t.Fatalf("expected symbolic-ref failure to be surfaced, got: %v", err)
 	}
 }

--- a/internal/git/cli/helpers_test.go
+++ b/internal/git/cli/helpers_test.go
@@ -21,6 +21,13 @@ var (
 	_ git.Logger    = (*gitcli.Logger)(nil)
 )
 
+// Isolate git from the developer's user/system config.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	os.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	os.Exit(m.Run())
+}
+
 // initBareRepo creates a bare git repository with a single commit on the
 // default branch. It returns the path to the bare repo directory.
 func initBareRepo(t *testing.T) string {

--- a/internal/git/cli/puller.go
+++ b/internal/git/cli/puller.go
@@ -25,7 +25,9 @@ func (c *Puller) Pull(ctx context.Context, opts git.PullOptions) (string, error)
 		fetchCmd.Env = append(fetchCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
 		_ = fetchCmd.Run()
 
-		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", opts.Branch)
+		// --end-of-options ensures a ref starting with "-" is treated as a
+		// ref, not as a git option (the ref comes from untrusted config).
+		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", "--end-of-options", opts.Branch)
 		checkoutCmd.Dir = opts.Dir
 		checkoutCmd.Env = append(checkoutCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
 		if err := checkoutCmd.Run(); err != nil {

--- a/internal/git/cli/puller.go
+++ b/internal/git/cli/puller.go
@@ -17,22 +17,40 @@ func NewPuller() *Puller {
 }
 
 func (c *Puller) Pull(ctx context.Context, opts git.PullOptions) (string, error) {
+	pinned := false
 	if opts.Branch != "" {
+		// Best-effort: surface newly-published tags before checkout.
+		fetchCmd := exec.CommandContext(ctx, "git", "fetch", "--tags", "--force")
+		fetchCmd.Dir = opts.Dir
+		fetchCmd.Env = append(fetchCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+		_ = fetchCmd.Run()
+
 		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", opts.Branch)
 		checkoutCmd.Dir = opts.Dir
 		checkoutCmd.Env = append(checkoutCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
 		if err := checkoutCmd.Run(); err != nil {
 			return "", fmt.Errorf("git checkout %s: %w", opts.Branch, err)
 		}
+
+		// Detached HEAD means a tag/SHA pin; skip pull so HEAD stays put.
+		symCmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
+		symCmd.Dir = opts.Dir
+		symCmd.Env = append(symCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+		pinned = symCmd.Run() != nil
 	}
 
-	// git pull
-	pullCmd := exec.CommandContext(ctx, "git", "pull", "--rebase=false")
-	pullCmd.Dir = opts.Dir
-	pullCmd.Env = append(pullCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
-	out, err := pullCmd.CombinedOutput()
-	if err != nil {
-		return strings.TrimSpace(string(out)), err
+	var out []byte
+	if pinned {
+		out = []byte(fmt.Sprintf("pinned to %s", opts.Branch))
+	} else {
+		pullCmd := exec.CommandContext(ctx, "git", "pull", "--rebase=false")
+		pullCmd.Dir = opts.Dir
+		pullCmd.Env = append(pullCmd.Environ(), "GIT_TERMINAL_PROMPT=0")
+		var err error
+		out, err = pullCmd.CombinedOutput()
+		if err != nil {
+			return strings.TrimSpace(string(out)), err
+		}
 	}
 
 	// Submodules are best-effort: a plugin whose submodule references an

--- a/internal/git/cli/puller_test.go
+++ b/internal/git/cli/puller_test.go
@@ -3,7 +3,9 @@ package cli_test
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tmuxpack/tpack/internal/git"
@@ -101,5 +103,89 @@ func TestPuller_PullWithBranch(t *testing.T) {
 	// feature.txt should now exist.
 	if _, err := os.Stat(filepath.Join(clone, "feature.txt")); err != nil {
 		t.Fatalf("expected feature.txt after pull with branch: %v", err)
+	}
+}
+
+// revParse returns the resolved SHA of HEAD (or any ref) for a repo.
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	out, err := exec.CommandContext(context.Background(),
+		"git", "-C", dir, "rev-parse", ref).Output()
+	if err != nil {
+		t.Fatalf("rev-parse %s in %s: %v", ref, dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestPuller_PullSkippedOnTag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+
+	// Tag the initial commit and push the tag upstream.
+	tagger := cloneLocal(t, bare)
+	runGit(t, tagger, "tag", "v1.0.0")
+	runGit(t, tagger, "push", "origin", "v1.0.0")
+	tagSHA := revParse(t, tagger, "v1.0.0")
+
+	// Clone fresh, then check out the tag so HEAD is detached.
+	clone := cloneLocal(t, bare)
+	runGit(t, clone, "fetch", "--tags")
+	runGit(t, clone, "checkout", "v1.0.0")
+
+	// Push a new commit upstream so a naive `git pull` would fast-forward.
+	addCommitToBare(t, bare, "after-tag.txt")
+
+	puller := gitcli.NewPuller()
+	_, err := puller.Pull(context.Background(), git.PullOptions{
+		Dir:    clone,
+		Branch: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("Pull pinned to tag returned error: %v", err)
+	}
+
+	if got := revParse(t, clone, "HEAD"); got != tagSHA {
+		t.Fatalf("HEAD moved off tag: HEAD=%s, want %s", got, tagSHA)
+	}
+
+	// The new file must NOT be present; pull should have been skipped.
+	if _, err := os.Stat(filepath.Join(clone, "after-tag.txt")); err == nil {
+		t.Fatal("after-tag.txt should not exist; pull should have been skipped on detached HEAD")
+	}
+}
+
+func TestPuller_PullSkippedOnCommitSHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+
+	// Capture the initial commit SHA and check it out (detached HEAD).
+	clone := cloneLocal(t, bare)
+	sha := revParse(t, clone, "HEAD")
+	runGit(t, clone, "checkout", sha)
+
+	// Push a new commit upstream so a naive `git pull` would fast-forward.
+	addCommitToBare(t, bare, "after-sha.txt")
+
+	puller := gitcli.NewPuller()
+	_, err := puller.Pull(context.Background(), git.PullOptions{
+		Dir:    clone,
+		Branch: sha,
+	})
+	if err != nil {
+		t.Fatalf("Pull pinned to SHA returned error: %v", err)
+	}
+
+	if got := revParse(t, clone, "HEAD"); got != sha {
+		t.Fatalf("HEAD moved off pinned SHA: HEAD=%s, want %s", got, sha)
+	}
+
+	if _, err := os.Stat(filepath.Join(clone, "after-sha.txt")); err == nil {
+		t.Fatal("after-sha.txt should not exist; pull should have been skipped on detached HEAD")
 	}
 }

--- a/internal/git/cli/puller_test.go
+++ b/internal/git/cli/puller_test.go
@@ -117,6 +117,32 @@ func revParse(t *testing.T, dir, ref string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// A ref starting with "-" must be treated as a ref (and fail to resolve),
+// never interpreted as a git option. Branch values come from untrusted config.
+func TestPuller_PullRejectsOptionLikeRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git CLI test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	clone := cloneLocal(t, bare)
+	before := revParse(t, clone, "HEAD")
+
+	puller := gitcli.NewPuller()
+	_, err := puller.Pull(context.Background(), git.PullOptions{
+		Dir:    clone,
+		Branch: "-q", // swallowed as the `git checkout -q` flag without --end-of-options
+	})
+	if err == nil {
+		t.Fatal("expected error for option-like ref; it was likely interpreted as a git flag")
+	}
+
+	// HEAD must be untouched by the failed checkout.
+	if got := revParse(t, clone, "HEAD"); got != before {
+		t.Fatalf("HEAD moved after failed checkout: HEAD=%s, want %s", got, before)
+	}
+}
+
 func TestPuller_PullSkippedOnTag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git CLI test in short mode")

--- a/internal/git/cli/refs.go
+++ b/internal/git/cli/refs.go
@@ -1,0 +1,9 @@
+package cli
+
+import "regexp"
+
+var commitSHArgx = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
+func looksLikeCommitSHA(ref string) bool {
+	return commitSHArgx.MatchString(ref)
+}


### PR DESCRIPTION
Closes #18 

This PR adds a feature to `tpack` allowing it to support git commit SHAs.