### PR TITLE
fix: drop hardcoded foreground on browse repo name

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -121,7 +121,6 @@ func NewTheme(primary, secondary, accent, errC, muted, text color.Color) Theme {
 			Foreground(accent),
 
 		BrowseRepoStyle: lipgloss.NewStyle().
-			Foreground(text).
 			Bold(true),
 
 		BrowseDescStyle: lipgloss.NewStyle().


### PR DESCRIPTION
Drop the hardcoded foreground color on the browse repo name so it inherits the terminal default.

It was unreadable on light backgrounds. Bold stays.

Fixes https://github.com/tmuxpack/tpack/issues/26