### PR TITLE
fix: download_binary.sh not working on some freebsd machines

### DIFF
--- a/lib/download_binary.sh
+++ b/lib/download_binary.sh
@@ -24,7 +24,7 @@ _download_tpack() {
 	# Detect architecture
 	local arch
 	case "$(uname -m)" in
-		x86_64)  arch="amd64" ;;
+		amd64|x86_64)  arch="amd64" ;;
 		aarch64|arm64) arch="arm64" ;;
 		*) return 1 ;;
 	esac


### PR DESCRIPTION
On FreeBSD (specifically OPNsense) `uname -m` reports amd64
This allows the tpack binary to be downloaded on these machines